### PR TITLE
Added Quick Benchmark Metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,55 @@ easy-edge list
 easy-edge remove gemma-3-1b-it-qat-q4_0-gguf
 ```
 
+### Benchmark Model Performance
+
+Measure model speed (tokens/sec, latency) and memory usage:
+
+**Single prompt benchmark:**
+```bash
+easy-edge benchmark --prompt "Hello, world!" --repeat 10 --model <model_name>
+```
+
+**Benchmark with prompt file:**
+```bash
+easy-edge benchmark --promptfile prompts.txt --model <model_name>
+```
+
+**Command Options:**
+- `--prompt`: Single prompt to benchmark
+- `--promptfile`: Path to file with prompts (Modelfile MESSAGE format)
+- `--repeat`: Number of times to repeat the benchmark (default: 1)
+- `--model`: Model name to benchmark (required)
+
+**Prompt File Format:**
+```
+MESSAGE user How can I reset my password?
+MESSAGE user How are you?
+MESSAGE user What is the capital of France?
+```
+
+**Measured Metrics:**
+- Total tokens generated
+- Average time to first token (seconds)
+- Tokens per second (throughput)
+- Throughput speed (requests per second)
+- Peak memory usage (MB)
+
+
+**Example Output:**
+```
+                     Benchmark Results                      
+
+  Metric                        Value                      
+ ──────────────────────────────────────────────────────────
+  Model                         Llama-3.2-1B-Instruct-GGUF
+  Total tokens                  346
+  Avg time to first token (s)   1.117
+  Tokens/sec                    30.97
+  Throughput speed (req/s)      0.90
+  Peak memory (MB)              1898.21
+```
+
 ## Configuration
 
 The tool stores configuration in `models/config.json`. You can modify settings like:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ easy-edge benchmark --prompt "Hello, world!" --repeat 10 --model <model_name>
 
 **Benchmark with prompt file:**
 ```bash
-easy-edge benchmark --promptfile prompts.txt --model <model_name>
+easy-edge benchmark --promptfile benchmark_prompts.txt --model <model_name>
 ```
 
 **Command Options:**
@@ -89,11 +89,29 @@ easy-edge benchmark --promptfile prompts.txt --model <model_name>
 - `--model`: Model name to benchmark (required)
 
 **Prompt File Format:**
+Create a text file (e.g., `benchmark_prompts.txt`) with prompts in Modelfile MESSAGE format:
+
 ```
 MESSAGE user How can I reset my password?
 MESSAGE user How are you?
 MESSAGE user What is the capital of France?
+MESSAGE user Explain quantum computing in simple terms.
+MESSAGE user Write a short poem about technology.
 ```
+
+**Prompt File Rules:**
+- **Format**: `MESSAGE user <your prompt here>`
+- **Only user messages**: Only lines starting with `MESSAGE user` are processed
+- **One prompt per line**: Each line should contain one complete prompt
+- **UTF-8 encoding**: Save the file in UTF-8 encoding
+- **File extension**: Use `.txt` extension for easy identification
+
+**Benefits of Using Prompt Files:**
+- **Batch testing**: Test multiple prompts in one run
+- **Consistent testing**: Use the same set of prompts across different models
+- **Realistic scenarios**: Test with diverse, real-world prompts
+- **Automation**: Easy to integrate into automated testing workflows
+- **Comprehensive benchmarking**: Get performance metrics across different prompt types and lengths
 
 **Measured Metrics:**
 - Total tokens generated
@@ -110,11 +128,10 @@ MESSAGE user What is the capital of France?
   Metric                        Value                      
  ──────────────────────────────────────────────────────────
   Model                         Llama-3.2-1B-Instruct-GGUF
-  Total tokens                  346
-  Avg time to first token (s)   1.117
-  Tokens/sec                    30.97
-  Throughput speed (req/s)      0.90
-  Peak memory (MB)              1898.21
+  Avg time to first token (s)   2.514
+  Tokens/sec                    30.23
+  Throughput speed (req/s)      27.30
+  Peak memory (MB)              1896.89
 ```
 
 ## Configuration

--- a/benchmark_prompts.txt
+++ b/benchmark_prompts.txt
@@ -1,0 +1,5 @@
+MESSAGE user How can I reset my password?
+MESSAGE user How are you?
+MESSAGE user What is the capital of France?
+MESSAGE user Explain quantum computing in simple terms.
+MESSAGE user Write a short poem about technology. 

--- a/easy_edge.py
+++ b/easy_edge.py
@@ -31,6 +31,8 @@ import urllib.request
 import zipfile
 import psutil
 import time
+from rich.table import Table
+from rich import box
 
 # Try to import llama-cpp-python
 try:
@@ -596,9 +598,6 @@ def finetune(ctx, modelfile, output, name, epochs, batch_size, learning_rate):
 @click.pass_context
 def benchmark(ctx, prompt, promptfile, repeat, model_name):
     """Benchmark model speed (tokens/sec, latency) and memory usage."""
-    import re
-    from rich.table import Table
-    from rich import box
 
     easy_edge = ctx.obj['easy_edge']
     model_path = easy_edge.get_model_path(model_name)

--- a/easy_edge.py
+++ b/easy_edge.py
@@ -669,7 +669,6 @@ def benchmark(ctx, prompt, promptfile, repeat, model_name):
     avg_first_token = sum(first_token_times) / total_runs if total_runs else 0
     tokens_per_sec = total_tokens / total_time if total_time > 0 else 0
     throughput_speed = total_runs / total_time if total_time > 0 else 0  # requests per second
-    import platform
     table = Table(title="Benchmark Results", box=box.SIMPLE)
     table.add_column("Metric", style="bold")
     table.add_column("Value")

--- a/easy_edge.py
+++ b/easy_edge.py
@@ -664,23 +664,21 @@ def benchmark(ctx, prompt, promptfile, repeat, model_name):
             first_token_times.append(latency)
     # Results
     total_runs = repeat * len(prompts)
+    total_time = sum(all_latencies)
     avg_latency = sum(all_latencies) / total_runs if total_runs else 0
     avg_first_token = sum(first_token_times) / total_runs if total_runs else 0
-    tokens_per_sec = total_tokens / sum(all_latencies) if sum(all_latencies) > 0 else 0
+    tokens_per_sec = total_tokens / total_time if total_time > 0 else 0
+    throughput_speed = total_runs / total_time if total_time > 0 else 0  # requests per second
     import platform
     table = Table(title="Benchmark Results", box=box.SIMPLE)
     table.add_column("Metric", style="bold")
     table.add_column("Value")
     table.add_row("Model", model_name)
-    table.add_row("Prompt count", str(len(prompts)))
-    table.add_row("Repeat", str(repeat))
-    table.add_row("Total runs", str(total_runs))
     table.add_row("Total tokens", str(total_tokens))
-    table.add_row("Avg latency (s)", f"{avg_latency:.3f}")
     table.add_row("Avg time to first token (s)", f"{avg_first_token:.3f}")
     table.add_row("Tokens/sec", f"{tokens_per_sec:.2f}")
+    table.add_row("Throughput speed (req/s)", f"{throughput_speed:.2f}")
     table.add_row("Peak memory (MB)", f"{peak_mem / (1024*1024):.2f}")
-    # table.add_row("Platform", platform.platform())
     console.print(table)
 
 if __name__ == '__main__':

--- a/easy_edge.py
+++ b/easy_edge.py
@@ -599,14 +599,13 @@ def finetune(ctx, modelfile, output, name, epochs, batch_size, learning_rate):
 def benchmark(ctx, prompt, promptfile, repeat, model_name):
     """Benchmark model speed (tokens/sec, latency) and memory usage."""
 
-
     easy_edge = ctx.obj['easy_edge']
     model_path = easy_edge.get_model_path(model_name)
     if not model_path:
         console.print(f"❌ Model '{model_name}' not found. Use 'easy-edge pull <model>' to download it.")
         return
 
-    # Load prompts
+    # Loading the prompts
     prompts = []
     if promptfile:
         with open(promptfile, 'r', encoding='utf-8') as f:
@@ -623,7 +622,7 @@ def benchmark(ctx, prompt, promptfile, repeat, model_name):
         console.print("[bold red]You must provide either --prompt or --promptfile.[/bold red]")
         return
 
-    # Prepare model
+    # Preparing the model
     console.print(f"[bold green]Loading model {model_name}...[/bold green]")
     llm = Llama(
         model_path=str(model_path),
@@ -676,7 +675,7 @@ def benchmark(ctx, prompt, promptfile, repeat, model_name):
     avg_latency = sum(all_latencies) / total_runs if total_runs else 0
     avg_first_token = sum(first_token_times) / total_runs if total_runs else 0
     tokens_per_sec = total_tokens / total_time if total_time > 0 else 0
-    throughput_speed = total_runs / total_time if total_time > 0 else 0  # requests per second
+    throughput_speed = completion_tokens_count / total_time if total_time > 0 else 0  # requests per second
     table = Table(title="Benchmark Results", box=box.SIMPLE)
     table.add_column("Metric", style="bold")
     table.add_column("Value")

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ multidict==6.6.3
 multiprocess==0.70.16
 networkx==3.2.1
 nh3==0.2.22
-numpy==2.0.2
+numpy==1.24.3
 packaging==25.0
 pandas==2.3.1
 peft==0.16.0


### PR DESCRIPTION
Added CLI commands that runs a fixed prompt (or set of prompts) and reports the following metrics:

- Time to first token
- Total tokens/sec
- Throughput speed
- Peak memory usage

The CLI command formats are mentioned in the Readme.md file.
<img width="899" height="211" alt="image" src="https://github.com/user-attachments/assets/370d20ee-bb3b-49e1-a1e2-a3b6297af313" />
